### PR TITLE
Rotate TagLogger only if self.db_file exists.

### DIFF
--- a/rem/journal.py
+++ b/rem/journal.py
@@ -96,8 +96,9 @@ class TagLogger(Unpickable(lock = PickableRLock.create), ICallbackAcceptor):
         logging.info("TagLogger.Rotate")
         with self.lock:
             self.file.close()
-            new_filename = "%s-%d" % (self.db_file, time.time())
-            os.rename(self.db_file, new_filename)
+            if os.path.exists(self.db_file):
+                new_filename = "%s-%d" % (self.db_file, time.time())
+                os.rename(self.db_file, new_filename)
             self.Open(self.db_file)
 
     def Clear(self, final_time):


### PR DESCRIPTION
If self.Open(self.db_file) fails after rename at least once (e.g. because of not enough space), there is no chance to recreate self.db_file in the future (and all scheduler.RollBackup() fails because of it).

So, lets rename only if self.db_file exists.
