### PR TITLE
Job.shell may contains Unicode, so encode it in utf-8 in rem.messages

### DIFF
--- a/rem/messages.py
+++ b/rem/messages.py
@@ -50,7 +50,12 @@ class PacketExecutionError(IMessageHelper):
         mbuf = cStringIO.StringIO()
 
         def appendJobItem(job, itemName):
-            print >> mbuf, "\t%s: %s" % (itemName, job.get(itemName, "N/A"))
+            def get(key):
+                val = job.get(key, "N/A")
+                if isinstance(val, unicode):
+                    val = val.encode('utf-8')
+                return val
+            print >> mbuf, "\t%s: %s" % (itemName, get(itemName))
 
         def appendJobResults(job):
             if job.get("results"):


### PR DESCRIPTION
Смысл в том, что кириллица в Job.shell приводила к:
1. падал PacketExecutionError::message на 'ascii' codec can't encode character u'...
2. job._finalize_job_iteration падал сначала в try, а потом и в except
3. job.Run не доходил до self.FireEvent("done")
4. не было packet.OnDone
5. не было FireEvent("job_done", job)
6. не было queue.working.discard(ref)
7. джоба навсегда оставалась в queue.working и занимала в ней место

Получилось как-то отстойно, посоветуй что-нибудь
