### PR TITLE
Hack to prevent fail on changeState/ReleasePlace race

### DIFF
--- a/rem/packet.py
+++ b/rem/packet.py
@@ -156,7 +156,7 @@ class JobPacketImpl(object):
                     file.Unlink(self, binname)
                 except OSError as e:
                     if e.errno == errno.ENOENT:
-                        logging.exception("Packet %s release place error: %s", self.id, e)
+                        logging.exception("Packet %s release place error", self.id)
                     else:
                         raise
                 filehash = file.checksum
@@ -204,7 +204,7 @@ class JobPacketImpl(object):
             try:
                 shutil.rmtree(self.directory, onerror=None)
             except Exception, e:
-                logging.exception("Packet %s release place error: %s", self.id, e)
+                logging.exception("Packet %s release place error", self.id)
         self.directory = None
         self.streams.clear()
 
@@ -235,7 +235,7 @@ class JobPacketImpl(object):
             try:
                 files = os.listdir(self.directory)
             except Exception, e:
-                logging.exception("directory %s listing error: %s", self.directory, e)
+                logging.exception("directory %s listing error", self.directory)
         return files
 
     def GetFile(self, filename):

--- a/rem/packet.py
+++ b/rem/packet.py
@@ -156,7 +156,7 @@ class JobPacketImpl(object):
                     file.Unlink(self, binname)
                 except OSError as e:
                     if e.errno == errno.ENOENT:
-                        logging.error("Packet %s release place error: %s", self.id, e)
+                        logging.exception("Packet %s release place error: %s", self.id, e)
                     else:
                         raise
                 filehash = file.checksum
@@ -204,7 +204,7 @@ class JobPacketImpl(object):
             try:
                 shutil.rmtree(self.directory, onerror=None)
             except Exception, e:
-                logging.error("Packet %s release place error: %s", self.id, e)
+                logging.exception("Packet %s release place error: %s", self.id, e)
         self.directory = None
         self.streams.clear()
 


### PR DESCRIPTION
Как известно, JobPacket.changeState (как и весь остальной код в REM) содержит гонки
(и при этом там везде используется self.state, а не фиксированный state).

Я не пофиксил эту гонку сейчас потому, что пока медитировал над rem.log нашёл кое-что,
что я пока не смог объяснить:
    Вызов changeState(PacketState.PENDING) дошёл примерно до Scheduler.Notify и пробыл там
    где-то 50 секунд, после чего догнал вызов changeState(PacketState.SUCCESSFULL) (между
    ними был ещё changeState(PacketState.WORKABLE), который нигде не зависал) и эти два
    вызова (PENDING, SUCCESSFULL) подрались в ReleasePlace.

Кусочек лога: http://pastie.org/pastes/10464021/text?key=xgyesiv3aimb7bk6jvajyw

```
1: PENDING                                      2: SUCCESSFULL
tmpLinks, self.binLinks = self.binLinks, {}
                                                tmpLinks, self.binLinks = self.binLinks, {}
file.Unlink(self, binname)
with self.lock:
    if os.path.islink(dstname):
                                                shutil.rmtree(self.directory, onerror=None)
        os.unlink(dstname) -> ENOENT
```
